### PR TITLE
Remove trailing whitespace from project template

### DIFF
--- a/template/app_controller.cpp
+++ b/template/app_controller.cpp
@@ -15,7 +15,7 @@ AppController::AppController() :
 
     // the label is the full width of screen, set it to be center aligned
     helloLabel.setAlignment(TextLabelView::ALIGN_CENTER);
-    
+
     // set another text color
     helloLabel.setTextColor(display::TurquoiseColor);
 }

--- a/template/app_controller.h
+++ b/template/app_controller.h
@@ -14,10 +14,10 @@ using namespace mono::ui;
 // The App main controller object.
 // This template app will show a "hello" text in the screen
 class AppController : public mono::IApplication {
-    
+
     // This is the text label object that will displayed
     TextLabelView helloLabel;
-    
+
 public:
 
     // The default constructor
@@ -31,7 +31,7 @@ public:
 
     // Called automatically by Mono right after after it wakes from sleep
     void monoWakeFromSleep();
-    
+
 };
 
 #endif /* app_controller_h */


### PR DESCRIPTION
Noticed some trailing whitespace lines in the templates.
